### PR TITLE
[DNM] feat: single master deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+master.yaml

--- a/master.tmpl
+++ b/master.tmpl
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    name: redis
+    tier: service
+    env: prod
+spec:
+  ports:
+  - name: http
+    port: {{.portNumber}}
+    targetPort: {{.portNumber}}
+    protocol: TCP
+  selector:
+    name: redis
+    env: prod
+  type: NodePort
+
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: redis
+  labels:
+    tier: set
+    env: prod
+spec:
+  serviceName: redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: redis
+        env: prod
+        tier: app
+    spec:
+      # initialize the configuration file
+      initContainers:
+      - name: custom-conf
+        image: screwdrivercd/redisinit:{{.imageTag}}
+        volumeMounts:
+        - mountPath: /data
+          name: redis-data
+      containers:
+      - name: redis-master
+        image: redis:4
+        ports:
+        - containerPort: {{.portNumber}}
+        volumeMounts:
+        - mountPath: /data
+          name: redis-data
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+      annotations:
+        volume.beta.kubernetes.io/storage-class: basic
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,0 +1,13 @@
+---
+shared:
+  image: buildpack-deps:jessie
+  environment:
+    GOPATH: /sd/workspace
+
+jobs:
+  main:
+    steps:
+    - setup: |
+        wget -O /usr/local/bin/mplater https://github.com/FenrirUnbound/mplater/releases/download/v0.0.2/mplater
+        chmod +x /usr/local/bin/mplater
+    - create_spec: mplater -i ./master.tmpl -o ./master.yaml -x tagName=someTag -x portNumber=6379


### PR DESCRIPTION
## Context

Resque is based on a Redis datastore. This work is to get a simple Redis cluster deployment configuration.

Blocked by *Init Container* efforts

## Objective

Define a Kubernetes deployment spec that will deploy a Redis datastore

## References

* Helps deliver Feature screwdriver-cd/screwdriver#431